### PR TITLE
fix: make wallet initializer methods static

### DIFF
--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -18,7 +18,7 @@ export interface BitcoinWalletProps {
 
   getSignerAddress(): Address;
   checkIsAddressTypeP2tr(): boolean;
-  initialize(network: Network): Promise<BitcoinWallet>;
+  // initialize(network: Network): Promise<BitcoinWallet>;
   signPsbt(unsignedPsbt64: UnsignedPsbt, broadcast: boolean): Promise<string>;
   signPsbts(
     unsignedPsbts64: UnsignedPsbt[],
@@ -52,8 +52,6 @@ export abstract class BitcoinWallet implements BitcoinWalletProps {
   checkIsAddressTypeP2tr(): boolean {
     return this.runeAddress.addressType === AddressType.p2tr;
   }
-
-  abstract initialize(network: Network): Promise<BitcoinWallet>;
 
   abstract signPsbt(
     unsignedPsbt64: UnsignedPsbt,

--- a/src/wallets/magic-eden.ts
+++ b/src/wallets/magic-eden.ts
@@ -43,7 +43,10 @@ export class MagicEdenWallet extends BitcoinWallet {
     this.internalNetwork = transformNetworkToSatsConnect(network);
   }
 
-  override async initialize(network: Network): Promise<MagicEdenWallet> {
+  static async initialize(
+    provider: BitcoinProvider,
+    network: Network,
+  ): Promise<MagicEdenWallet> {
     try {
       const response = await request('getAddresses', {
         purposes: [AddressPurpose.Payment, AddressPurpose.Ordinals],
@@ -53,7 +56,7 @@ export class MagicEdenWallet extends BitcoinWallet {
         return new MagicEdenWallet(
           network,
           response.result.addresses,
-          this.provider,
+          provider,
         );
       } else {
         if (response.error.code === RpcErrorCode.USER_REJECTION) {

--- a/src/wallets/unisat.ts
+++ b/src/wallets/unisat.ts
@@ -26,7 +26,7 @@ export class UnisatWallet extends BitcoinWallet {
     this.internalChain = transformNetworkName(network);
   }
 
-  override async initialize(network: Network): Promise<UnisatWallet> {
+  static async initialize(network: Network): Promise<UnisatWallet> {
     if (window.unisat === undefined) {
       throw new WalletException('wallet_not_installed');
     }

--- a/src/wallets/xverse.ts
+++ b/src/wallets/xverse.ts
@@ -39,7 +39,10 @@ export class XverseWallet extends BitcoinWallet {
     this.internalNetwork = transformNetworkToSatsConnect(network);
   }
 
-  override async initialize(network: Network): Promise<XverseWallet> {
+  static async initialize(
+    provider: BitcoinProvider,
+    network: Network,
+  ): Promise<XverseWallet> {
     try {
       const response = await request('wallet_connect', {
         addresses: [AddressPurpose.Ordinals, AddressPurpose.Payment],
@@ -48,7 +51,7 @@ export class XverseWallet extends BitcoinWallet {
         return new XverseWallet(
           network,
           response.result.addresses,
-          this.provider,
+          provider,
           response.result.walletType,
         );
       } else {


### PR DESCRIPTION
The wallet initializer methods should be static. This is because constructors for individual wallets cannot be async. Also, different wallet implementations require different parameters to be provided to their constructors, so abstracting this is not straight forward.

Each wallet implementation should have it's own static  `initialize` method. There might be better solutions, but this works for now.